### PR TITLE
Implement make-offer modal and placeholder counts

### DIFF
--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -10,8 +10,11 @@ import { ThemeProvider  } from '../contexts/ThemeContext.js';
 import { WalletProvider } from '../contexts/WalletContext.js';
 import GlobalStyles       from '../styles/globalStyles.js';
 import { purgeExpiredSliceCache } from '../utils/sliceCache.js';
+import MakeOfferDialog from '../ui/MakeOfferDialog.jsx';
 
 export default function ZeroUnboundApp({ Component, pageProps }) {
+
+  const [offer, setOffer] = React.useState({ open:false, contract:'', tokenId:'', market:'' });
 
   /* one-time PWA SW registration */
   React.useEffect(() => {
@@ -26,6 +29,16 @@ export default function ZeroUnboundApp({ Component, pageProps }) {
     purgeExpiredSliceCache(1);
   }, []);
 
+  /* make-offer overlay listener */
+  React.useEffect(() => {
+    const handler = (e) => {
+      const { contract, tokenId, marketContract } = e.detail || {};
+      setOffer({ open:true, contract, tokenId, market: marketContract || '' });
+    };
+    window.addEventListener('zu:makeOffer', handler);
+    return () => window.removeEventListener('zu:makeOffer', handler);
+  }, []);
+
   return (
     <ThemeProvider>
       <WalletProvider>
@@ -38,6 +51,13 @@ export default function ZeroUnboundApp({ Component, pageProps }) {
         <Layout>
           <Component {...pageProps} />
         </Layout>
+        <MakeOfferDialog
+          open={offer.open}
+          contract={offer.contract}
+          tokenId={offer.tokenId}
+          marketContract={offer.market}
+          onClose={() => setOffer({ open:false, contract:'', tokenId:'', market:'' })}
+        />
       </WalletProvider>
     </ThemeProvider>
   );

--- a/src/pages/contracts/[addr].jsx
+++ b/src/pages/contracts/[addr].jsx
@@ -97,13 +97,11 @@ export default function ContractPage() {
         const r = await jFetch(`${TZKT_API}/contracts/${addr}`);
         let m   = r?.metadata ?? {};
         if (!m?.name) {
-          const bm = await jFetch(
-            `${TZKT_API}/contracts/${addr}/bigmaps/metadata/keys/contents`,
-          ).catch(() => null);
-          if (bm?.value) {
-            const decoded = decodeHexJson(bm.value);
-            if (decoded) m = { ...decoded, ...m };
-          }
+          const [v] = await jFetch(
+            `${TZKT_API}/contracts/${addr}/bigmaps/metadata/keys?key=content&select=value`,
+          ).catch(() => []);
+          const decoded = decodeHexJson(v);
+          if (decoded) m = { ...decoded, ...m };
         }
         if (!cancel) setMeta(decodeHexFields(m));
       } catch { if (!cancel) setMeta({}); }

--- a/src/pages/contracts/[addr].jsx
+++ b/src/pages/contracts/[addr].jsx
@@ -19,6 +19,7 @@ import TokenIdSelect              from '../../ui/TokenIdSelect.jsx';
 import FiltersPanel               from '../../ui/FiltersPanel.jsx';
 
 import countOwners      from '../../utils/countOwners.js';
+import countTokens      from '../../utils/countTokens.js';
 import listLiveTokenIds from '../../utils/listLiveTokenIds.js';
 import decodeHexFields, { decodeHexJson } from '../../utils/decodeHexFields.js';
 import { jFetch }       from '../../core/net.js';
@@ -66,7 +67,8 @@ export default function ContractPage() {
 
   const [meta, setMeta]       = useState(null);
   const [tokens, setTokens]   = useState([]);
-  const [owners, setOwners]   = useState(null);
+  const [tokCount, setTokCount] = useState('…');
+  const [owners, setOwners]   = useState('…');
   const [loading, setLoading] = useState(true);
   const [tokOpts, setTokOpts] = useState([]);
   const [tokSel,  setTokSel]  = useState('');
@@ -129,8 +131,13 @@ export default function ContractPage() {
       } finally { if (!cancel) setLoading(false); }
     })();
 
-    /* 3 · owners */
-    countOwners(addr, NETWORK).then((n) => { if (!cancel) setOwners(n); });
+    /* 3 · counts */
+    countOwners(addr, NETWORK).then((n) => {
+      if (!cancel) setOwners(n);
+    });
+    countTokens(addr, NETWORK).then((n) => {
+      if (!cancel) setTokCount(n);
+    });
 
     return () => { cancel = true; };
   }, [addr]);
@@ -213,9 +220,9 @@ export default function ContractPage() {
 
   /* stats */
   const stats = {
-    tokens : tokens.length,
-    owners : owners ?? '—',
-    sales  : tokens.filter((t) => Number(t.price) > 0).length,
+    tokens : tokCount,
+    owners : owners,
+    sales  : loading ? '…' : tokens.filter((t) => Number(t.price) > 0).length,
   };
 
   /*──────── render ─────────────────────────────────────────*/

--- a/src/pages/contracts/[addr].jsx
+++ b/src/pages/contracts/[addr].jsx
@@ -98,7 +98,7 @@ export default function ContractPage() {
         let m   = r?.metadata ?? {};
         if (!m?.name) {
           const [v] = await jFetch(
-            `${TZKT_API}/contracts/${addr}/bigmaps/metadata/keys?key=content&select=value`,
+            `${TZKT_API}/contracts/${addr}/bigmaps/metadata/keys?key=contents&select=value`,
           ).catch(() => []);
           const decoded = decodeHexJson(v);
           if (decoded) m = { ...decoded, ...m };

--- a/src/pages/contracts/[addr].jsx
+++ b/src/pages/contracts/[addr].jsx
@@ -97,11 +97,13 @@ export default function ContractPage() {
         const r = await jFetch(`${TZKT_API}/contracts/${addr}`);
         let m   = r?.metadata ?? {};
         if (!m?.name) {
-          const [v] = await jFetch(
-            `${TZKT_API}/contracts/${addr}/bigmaps/metadata/keys?key=contents&select=value`,
-          ).catch(() => []);
-          const decoded = decodeHexJson(v);
-          if (decoded) m = { ...decoded, ...m };
+          const bm = await jFetch(
+            `${TZKT_API}/contracts/${addr}/bigmaps/metadata/keys/contents`,
+          ).catch(() => null);
+          if (bm?.value) {
+            const decoded = decodeHexJson(bm.value);
+            if (decoded) m = { ...decoded, ...m };
+          }
         }
         if (!cancel) setMeta(decodeHexFields(m));
       } catch { if (!cancel) setMeta({}); }

--- a/src/pages/manage.js
+++ b/src/pages/manage.js
@@ -83,7 +83,7 @@ async function fetchMeta(addr = '', net = 'ghostnet') {
     const det  = await jFetch(base);
     let  meta  = det.metadata || {};
     if (!meta.name || !meta.imageUri) {
-      const bm = await jFetch(`${base}/bigmaps/metadata/keys/content`).catch(() => null);
+      const bm = await jFetch(`${base}/bigmaps/metadata/keys/contents`).catch(() => null);
       if (bm?.value) meta = { ...parseHex(bm.value), ...meta };
     }
     return {

--- a/src/ui/CollectionCard.jsx
+++ b/src/ui/CollectionCard.jsx
@@ -109,7 +109,7 @@ export default function CollectionCard({ contract }) {
       try{
         const rows = await jFetch(
           `${api}/contracts/${contract.address}/bigmaps/metadata/keys`
-          + '?key=content&select=value&limit=1',
+          + '?key=contents&select=value&limit=1',
         ).catch(()=>[]);
         const raw = rows?.[0];
         const parsed = decodeHexMetadata(raw);

--- a/src/ui/ContractCarousels.jsx
+++ b/src/ui/ContractCarousels.jsx
@@ -175,7 +175,7 @@ async function enrich(list, net, force = false) {
     let meta = detRaw?.metadata || {};
     if (!meta.name || !meta.imageUri) {
       const bm = await jFetch(
-        `${TZKT[net]}/contracts/${it.address}/bigmaps/metadata/keys/content`,
+        `${TZKT[net]}/contracts/${it.address}/bigmaps/metadata/keys/contents`,
       ).catch(() => null);
       if (bm?.value) meta = { ...parseHex(bm.value), ...meta };
     }

--- a/src/ui/ContractCarousels.jsx
+++ b/src/ui/ContractCarousels.jsx
@@ -111,14 +111,11 @@ async function isWalletCollaborator(addr, wallet, net) {
 
 async function fetchCollaborative(addr, net) {
   if (!addr) return [];
-  /* include all progressive (v3 / v4*) hashes so v4c is discovered */
-  const progHashes = Object.entries(HASHES[net])
-    .filter(([ver]) => ver.startsWith('v3') || ver.startsWith('v4'))
-    .map(([, h]) => h);
-  if (!progHashes.length) return [];
+  const hashes = [...new Set(Object.values(HASHES[net]))];
+  if (!hashes.length) return [];
 
   const cands = await jFetch(
-    `${TZKT[net]}/contracts?typeHash.in=${[...new Set(progHashes)].join(',')}&limit=200`,
+    `${TZKT[net]}/contracts?typeHash.in=${hashes.join(',')}&limit=200`,
   ).catch(() => []);
 
   const out = [];

--- a/src/ui/ContractMetaPanelContracts.jsx
+++ b/src/ui/ContractMetaPanelContracts.jsx
@@ -85,7 +85,7 @@ export default function ContractMetaPanelContracts({
   meta = {},
   contractAddress = '',
   network = 'ghostnet',
-  stats = { tokens:0, owners:0, sales:0 },
+  stats = { tokens:'…', owners:'…', sales:'…' },
 }) {
   const [copied, setCopied] = useState(false);
 
@@ -149,9 +149,9 @@ ContractMetaPanelContracts.propTypes = {
   contractAddress: PropTypes.string.isRequired,
   network: PropTypes.string,
   stats: PropTypes.shape({
-    tokens : PropTypes.number,
-    owners : PropTypes.oneOfType([PropTypes.number,PropTypes.string]),
-    sales  : PropTypes.number,
+    tokens : PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    owners : PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    sales  : PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   }),
 };
 /* What changed & why (r2):

--- a/src/ui/ContractMetaPanelContracts.jsx
+++ b/src/ui/ContractMetaPanelContracts.jsx
@@ -101,12 +101,10 @@ export default function ContractMetaPanelContracts({
   };
 
   const [thumbOk, setThumbOk] = useState(true);
-  const thumbSrc = meta.imageUri
-    || meta.thumbnailUri
-    || meta.displayUri
-    || '';
-  const showPlaceholder = !thumbSrc || !thumbOk;
-  const thumb = showPlaceholder ? PLACEHOLDER : ipfsToHttp(thumbSrc);
+  const thumb = ipfsToHttp(
+    meta.imageUri || meta.thumbnailUri || meta.displayUri || PLACEHOLDER,
+  );
+  const showPlaceholder = !thumbOk || thumb === PLACEHOLDER;
 
   return (
     <Card>

--- a/src/ui/ContractMetaPanelContracts.jsx
+++ b/src/ui/ContractMetaPanelContracts.jsx
@@ -101,9 +101,11 @@ export default function ContractMetaPanelContracts({
   };
 
   const [thumbOk, setThumbOk] = useState(true);
-  const thumb = thumbOk
-    ? ipfsToHttp(meta.imageUri || meta.thumbnailUri || meta.displayUri || '')
-    : PLACEHOLDER;
+  const thumbSrc = meta.imageUri
+    || meta.thumbnailUri
+    || meta.displayUri
+    || '';
+  const thumb = thumbOk ? ipfsToHttp(thumbSrc) : PLACEHOLDER;
 
   return (
     <Card>

--- a/src/ui/ContractMetaPanelContracts.jsx
+++ b/src/ui/ContractMetaPanelContracts.jsx
@@ -105,16 +105,21 @@ export default function ContractMetaPanelContracts({
     || meta.thumbnailUri
     || meta.displayUri
     || '';
-  const thumb = thumbOk ? ipfsToHttp(thumbSrc) : PLACEHOLDER;
+  const showPlaceholder = !thumbSrc || !thumbOk;
+  const thumb = showPlaceholder ? PLACEHOLDER : ipfsToHttp(thumbSrc);
 
   return (
     <Card>
       <Thumb>
-        <RenderMedia
-          uri={thumb}
-          alt={meta.name}
-          onInvalid={()=>setThumbOk(false)}
-        />
+        {showPlaceholder ? (
+          <img src={PLACEHOLDER} alt="" />
+        ) : (
+          <RenderMedia
+            uri={thumb}
+            alt={meta.name}
+            onInvalid={() => setThumbOk(false)}
+          />
+        )}
       </Thumb>
 
       <Body>

--- a/src/ui/Entrypoints/EditContractMetadata.jsx
+++ b/src/ui/Entrypoints/EditContractMetadata.jsx
@@ -126,7 +126,7 @@ export default function EditContractMetadata({
       if (row?.extras) m = { ...m, ...row.extras };
       if (!Object.keys(m).length) {
         const bm = await jFetch(
-          `${BASE}/contracts/${contractAddress}/bigmaps/metadata/keys/content`,
+          `${BASE}/contracts/${contractAddress}/bigmaps/metadata/keys/contents`,
         ).catch(() => null);
         if (bm?.value)
           m = JSON.parse(Buffer.from(bm.value.replace(/^0x/i, ''), 'hex').toString('utf8'));

--- a/src/ui/FiltersPanel.jsx
+++ b/src/ui/FiltersPanel.jsx
@@ -57,15 +57,23 @@ export default function FiltersPanel({ tokens = [], filters, setFilters, renderT
   });
 
   /* handlers */
+  const closeIfMobile = () => {
+    if (window.innerWidth < 1100) setShow(false);
+  };
+
   const toggleSetVal = (setName, val) => {
     setFilters((f) => {
       const s = new Set(f[setName]);
       s.has(val) ? s.delete(val) : s.add(val);
       return { ...f, [setName]: s };
     });
+    closeIfMobile();
   };
 
-  const onRadio = (key, val) => setFilters((f) => ({ ...f, [key]: val }));
+  const onRadio = (key, val) => {
+    setFilters((f) => ({ ...f, [key]: val }));
+    closeIfMobile();
+  };
 
   /* mobile modal close on resize */
   useEffect(() => {
@@ -148,7 +156,6 @@ export default function FiltersPanel({ tokens = [], filters, setFilters, renderT
         ))}
       </Section>
 
-      <PixelButton onClick={()=>setFilters({...filters})}>APPLY</PixelButton>
     </Panel>
   );
 

--- a/src/ui/MakeOfferDialog.jsx
+++ b/src/ui/MakeOfferDialog.jsx
@@ -1,0 +1,81 @@
+/*Developed by @jams2blues with love for the Tezos community
+  File: src/ui/MakeOfferDialog.jsx
+  Summary: simple make_offer entrypoint modal */
+
+import React, { useState } from 'react';
+import styledPkg from 'styled-components';
+import PixelInput from './PixelInput.jsx';
+import PixelButton from './PixelButton.jsx';
+import { useWalletContext } from '../contexts/WalletContext.js';
+
+const styled = typeof styledPkg === 'function' ? styledPkg : styledPkg.default;
+
+const Back = styled.div`
+  position:fixed;inset:0;display:flex;align-items:center;justify-content:center;
+  background:rgba(0,0,0,.86);z-index:2600;
+`;
+const Panel = styled.div`
+  width:90vw;max-width:360px;background:#0b0b0b;color:#fff;
+  border:2px solid #bebebe;padding:1.5rem;box-shadow:0 0 12px #000;
+  display:flex;flex-direction:column;gap:.75rem;font-family:var(--font-pixel);
+`;
+
+export default function MakeOfferDialog({
+  open = false,
+  contract = '',
+  tokenId = '',
+  marketContract = '',
+  onClose = () => {},
+}) {
+  const { toolkit } = useWalletContext() || {};
+  const [amount, setAmount] = useState('1');
+  const [price, setPrice] = useState('');
+  const [busy, setBusy] = useState(false);
+
+  if (!open) return null;
+
+  const send = async () => {
+    const kit = toolkit || window.tezosToolkit;
+    const amtN = Number(amount);
+    const priceMutez = Math.floor(parseFloat(price) * 1_000_000);
+    if (!kit?.wallet) return alert('Connect wallet first');
+    if (!Number.isFinite(amtN) || amtN <= 0) return alert('Bad amount');
+    if (!Number.isFinite(priceMutez) || priceMutez <= 0) return alert('Bad price');
+    if (!marketContract) return alert('Market contract missing');
+    try {
+      setBusy(true);
+      const c = await kit.wallet.at(marketContract);
+      const op = await c.methods.make_offer(amtN, contract, priceMutez, Number(tokenId)).send();
+      await op.confirmation();
+      onClose();
+    } catch (e) {
+      alert(e.message);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Back onClick={onClose}>
+      <Panel onClick={(e)=>e.stopPropagation()}>
+        <h3 style={{margin:'0 0 .5rem'}}>Make Offer</h3>
+        <PixelInput
+          placeholder="Amount"
+          value={amount}
+          onChange={(e)=>setAmount(e.target.value)}
+        />
+        <PixelInput
+          placeholder="Price ꜩ"
+          value={price}
+          onChange={(e)=>setPrice(e.target.value)}
+        />
+        <div style={{display:'flex',gap:'1rem',justifyContent:'center'}}>
+          <PixelButton onClick={send} disabled={busy}>OK</PixelButton>
+          <PixelButton onClick={onClose} disabled={busy}>Cancel</PixelButton>
+        </div>
+      </Panel>
+    </Back>
+  );
+}
+
+/* What changed & why: new dialog for make_offer */

--- a/src/ui/TokenCard.jsx
+++ b/src/ui/TokenCard.jsx
@@ -107,13 +107,13 @@ export default function TokenCard({
   const hidden = (nsfw && !allowNSFW) || (flashing && !allowFlash);
 
   /* pick best preview */
-  const preview = ipfsToHttp(
+  const previewSrc =
     meta.displayUri   ||
     meta.imageUri     ||
     meta.thumbnailUri ||
     meta.artifactUri  ||
-    '',
-  );
+    '';
+  const preview = ipfsToHttp(previewSrc);
 
   const [thumbOk, setThumbOk] = useState(true);
   const onInvalid = useCallback(() => setThumbOk(false), []);

--- a/src/ui/TokenCard.jsx
+++ b/src/ui/TokenCard.jsx
@@ -19,6 +19,8 @@ import PixelButton        from './PixelButton.jsx';
 import IntegrityBadge     from './IntegrityBadge.jsx';
 import { shortKt }        from '../utils/formatAddress.js';
 
+const PLACEHOLDER = '/sprites/cover_default.svg';
+
 const styled = typeof styledPkg === 'function' ? styledPkg : styledPkg.default;
 
 /*──────── styled shells (unchanged) ──────────────────────────*/
@@ -143,7 +145,7 @@ export default function TokenCard({
     }));
   };
 
-  if (!thumbOk) return null;
+  const showPlaceholder = !thumbOk || !preview;
 
   /* authors fallback chain: authors → artists → creators */
   const authorArr = meta.authors || meta.artists || meta.creators || [];
@@ -171,7 +173,7 @@ export default function TokenCard({
           </Obf>
         )}
 
-        {!hidden && (
+        {!hidden && !showPlaceholder && (
           <RenderMedia
             uri={preview}
             mime={meta.mimeType}
@@ -179,6 +181,13 @@ export default function TokenCard({
             allowScripts={scriptHaz && allowScripts}
             style={{ width:'100%', height:'100%', objectFit:'contain' }}
             onInvalid={onInvalid}
+          />
+        )}
+        {!hidden && showPlaceholder && (
+          <img
+            src={PLACEHOLDER}
+            alt=""
+            style={{ width:'60%', opacity:.45 }}
           />
         )}
 


### PR DESCRIPTION
## Summary
- add countTokens usage and ellipsis placeholders on contract page
- update ContractMetaPanelContracts prop-types
- add placeholder fallback for TokenCard previews
- simplify FiltersPanel and auto-close on mobile
- add MakeOfferDialog and global event listener

## Testing
- `yarn lint` *(fails: Couldn't find node_modules)*
- `yarn build` *(fails: Couldn't find node_modules)*
- `yarn test` *(fails: Couldn't find node_modules)*

------
https://chatgpt.com/codex/tasks/task_e_6866cb0c22508330931b3401e2179122