### PR TITLE
Fix origination timeout overlay

### DIFF
--- a/src/pages/api/forge.js
+++ b/src/pages/api/forge.js
@@ -4,7 +4,6 @@
   Rev :    r1   2025‑07‑15
   Summary: serverless forge endpoint
 ──────────────────────────────────────────────────────────────*/
-import { TezosToolkit } from '@taquito/taquito';
 import { packDataBytes, forgeOperations } from '@taquito/rpc';
 
 export default async function handler(req, res) {
@@ -14,7 +13,6 @@ export default async function handler(req, res) {
     const { code, storage } = req.body;
     if (!code || !storage) return res.status(400).json({ error: 'Missing code/storage' });
 
-    const tk = new TezosToolkit(process.env.RPC_URL || 'https://rpc.tzkt.io/ghostnet');
     const packed = await packDataBytes(storage);
     const forged = await forgeOperations([{
       branch: 'head',

--- a/src/pages/deploy.js
+++ b/src/pages/deploy.js
@@ -4,7 +4,7 @@
   Rev :    r752   2025‑07‑15
   Summary: increase worker timeout to 60s; add error on worker fail
 ──────────────────────────────────────────────────────────────*/
-import React, { useRef, useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { MichelsonMap }                                     from '@taquito/michelson-encoder';
 import { char2Bytes }                                       from '@taquito/utils';
 
@@ -19,15 +19,6 @@ import contractCode         from '../../contracts/Zero_Contract_V4.tz';
 const worker = typeof window !== 'undefined' ? new Worker(new URL('../workers/originate.worker.js', import.meta.url)) : null;
 
 /*──────── helpers ─────*/
-const uniqInterfaces = (src = []) => {
-  const base = ['TZIP-012', 'TZIP-016'];
-  const map  = new Map();
-  [...src, ...base].forEach((i) => {
-    const k = String(i ?? '').trim();
-    if (k) map.set(k.toUpperCase(), k);
-  });
-  return Array.from(map.values());
-};
 
 /*──────── constants ─────*/
 const blank = () => new MichelsonMap();
@@ -72,11 +63,13 @@ export default function DeployPage() {
     setStep(0); setLabel('Compressing metadata'); setPct(0);
 
     const taskId = Date.now().toString();
-    const timeoutId = setTimeout(() => {
-      setErr('Metadata compression timeout after 60s');
-      worker.terminate();
-      reset();
-    }, 60000);
+      const timeoutId = setTimeout(() => {
+        worker.terminate();
+        setStep(-1);
+        setPct(0);
+        setLabel('');
+        setErr('Metadata compression timeout after 60s');
+      }, 60000);
 
     const onMessage = (e) => {
       const d = e.data;


### PR DESCRIPTION
### Impacted Files
- src/pages/api/forge.js
- src/pages/deploy.js

### What changed & why
Timeout during metadata compression silently reset the overlay. The worker now terminates and exposes the error instead of hiding it. Removed unused helper and import. Also cleaned the forge API endpoint by dropping an unused toolkit instance.

| rev | ✔ | files | outcome |
| --- | --- | --- | --- |
| b0496df | ❌ | 2 | `yarn lint` found warnings; tests failed due to missing setup |


------
https://chatgpt.com/codex/tasks/task_e_68772472d92c833090224108abe948dd