### PR TITLE
fix(codex): support v2a token listing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## 2025-08-10
+- fix: enable v2a token listings by adding token_id+1 ledger fallback and updating listing workflow.

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -2,13 +2,13 @@
 /*───────────────────────────────────────────────────────────────
 Developed by @jams2blues – ZeroContract Studio
 File:    jest.config.cjs
-Rev :    r2   2025‑07‑15
-Summary: add tests for views.hex.js & chooseFastestRpc.js
+Rev :    r3   2025‑08‑10
+Summary: include tests/ directory and support CommonJS helper.
 ───────────────────────────────────────────────────────────────*/
 module.exports = {
   testEnvironment: 'jsdom',
-  testMatch: ['**/__tests__/**/*.test.[jt]s?(x)'],
+  testMatch: ['**/__tests__/**/*.test.[jt]s?(x)', '**/tests/**/*.test.[jt]s?(x)'],
   collectCoverage: false,
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
 };
-/* What changed & why: Added setup file for jest-dom; rev r2. */
+/* What changed & why: Added tests/ directory; switched helper to CJS. */

--- a/src/utils/getLedgerBalanceV2a.cjs
+++ b/src/utils/getLedgerBalanceV2a.cjs
@@ -1,0 +1,34 @@
+/*─────────────────────────────────────────────────────────────
+Developed by @jams2blues – ZeroContract Studio
+File:    src/utils/getLedgerBalanceV2a.cjs
+Rev :    r1    2025-08-10
+Summary: Direct ledger lookup for v2a contracts with 1-based token ids.
+         Attempts token_id and token_id+1 to fetch edition balance
+         from the ledger big_map.
+─────────────────────────────────────────────────────────────*/
+async function getLedgerBalanceV2a(toolkit, contract, pkh, id) {
+  try {
+    const tzkt = /ghostnet|limanet/i.test(toolkit.rpc.getRpcUrl?.() ?? '')
+      ? 'https://api.ghostnet.tzkt.io'
+      : 'https://api.tzkt.io';
+    const maps = await (await fetch(`${tzkt}/v1/contracts/${contract}/bigmaps`)).json();
+    const ledMap = maps.find((m) => m.path === 'ledger');
+    if (!ledMap) return 0;
+    const mapId = ledMap.ptr ?? ledMap.id;
+    const attempt = async (tokenId) => {
+      const q = `${tzkt}/v1/bigmaps/${mapId}/keys?key.0=${pkh}&key.1=${tokenId}`;
+      const rows = await (await fetch(q)).json();
+      if (Array.isArray(rows) && rows.length > 0) {
+        return Number(rows[0]?.value ?? 0);
+      }
+      return 0;
+    };
+    const bal = await attempt(id);
+    if (bal > 0) return bal;
+    return await attempt(id + 1);
+  } catch {
+    return 0;
+  }
+}
+module.exports = getLedgerBalanceV2a;
+/* What changed & why: Introduced helper for v2a ledger lookups with token_id+1 fallback. */

--- a/tests/v2aLedger.test.js
+++ b/tests/v2aLedger.test.js
@@ -1,0 +1,35 @@
+/* eslint-env jest */
+const getLedgerBalanceV2a = require('../src/utils/getLedgerBalanceV2a.cjs');
+
+describe('getLedgerBalanceV2a', () => {
+  afterEach(() => {
+    global.fetch?.mockReset?.();
+  });
+
+  it('falls back to token_id + 1 when initial lookup is empty', async () => {
+    const toolkit = { rpc: { getRpcUrl: () => 'https://ghostnet.example' } };
+    const contract = 'KT1TEST';
+    const pkh = 'tz1abc';
+
+    global.fetch = jest
+      .fn()
+      // bigmaps lookup
+      .mockResolvedValueOnce({
+        json: async () => [{ path: 'ledger', ptr: 123 }],
+      })
+      // first ledger query (token_id)
+      .mockResolvedValueOnce({
+        json: async () => [],
+      })
+      // second ledger query (token_id + 1)
+      .mockResolvedValueOnce({
+        json: async () => [{ value: 7 }],
+      });
+
+    const bal = await getLedgerBalanceV2a(toolkit, contract, pkh, 0);
+    expect(bal).toBe(7);
+    expect(fetch).toHaveBeenCalledTimes(3);
+    expect(fetch.mock.calls[1][0]).toMatch('key.1=0');
+    expect(fetch.mock.calls[2][0]).toMatch('key.1=1');
+  });
+});


### PR DESCRIPTION
## Summary
- adjust listing flow to try token_id+1 for v2a tokens and read ledger balances accordingly
- add CommonJS helper and test for v2a ledger lookup
- expand Jest config to include tests directory

## Testing
- `yarn lint` *(fails: Visible, non-interactive elements with click handlers must have at least one keyboard listener, etc.)*
- `npx eslint src/ui/ListTokenDialog.jsx src/utils/getLedgerBalanceV2a.cjs tests/v2aLedger.test.js jest.config.cjs --max-warnings 0`
- `yarn test`
- `yarn build`

| rev | ✔ | files | outcome |
| --- | --- | ----- | ------- |
| r1 | ✔ | 5 | v2a listing fix |


------
https://chatgpt.com/codex/tasks/task_e_68935f38de148330bc531574282567f1