### PR TITLE
feat(codex): add v2a marketplace support

### DIFF
--- a/docs/AI_CUSTOM_INSTRUCTIONS.md
+++ b/docs/AI_CUSTOM_INSTRUCTIONS.md
@@ -1,8 +1,8 @@
 /*─────────────────────────────────────────────────────────────
 Developed by @jams2blues – ZeroContract Studio
 File: docs/AI_CUSTOM_INSTRUCTIONS.md
-Rev : r7 2025‑07‑24 UTC
-Summary: unify origination flow; remove remote forge service; update environment guidance.
+Rev : r10 2025‑08‑06 UTC
+Summary: add Codex handoff guidance for dual marketplace rollout and v2a offline balance guard.
 */
 
 AI Custom Instructions — Zero Unbound
@@ -40,4 +40,22 @@ Unchanged. Apologise, provide corrected output, note the breach and log a new se
 
 Other sections remain unchanged from the previous revision.
 
-/* What changed & why: Updated to r7. Removed the remote forge service and Temple-specific forging path. All wallets now use TezosToolkit.wallet.originate() with a single‑stage origination. FAST_ORIGIN and USE_BACKEND remain removed. Updated summary and Tools & Environment guidance accordingly. */
+## ZeroUnbound — Codex Handoff (v2 2025‑08‑06)
+### Context
+* Ghostnet now runs **two** ZeroSum instances:
+  `KT1R1Pz…t1p` (legacy READ‑ONLY) and `KT19yn9…n1z` (new READ/WRITE).
+* Contract **v2a** must set the bool flag **offline_balance = True** and pass
+  the checklist guard inside the new marketplace.
+* The front‑end must:
+  1. Detect v2a via `hashMatrix.json`.
+  2. Verify balance via  
+     `GET {TZKT_API}/v1/tokens/balances?token.contract=<cid>&token.tokenId=<tid>&account=<pkh>`
+     and abort if `"balance": "0"`.
+  3. Call `buildListParams()` with `{ offline_balance:true }`.
+  4. Send all write operations to `MARKETPLACE_WRITE_ADDRESS`.
+  5. Aggregate listings/offers from **all** `MARKETPLACE_READ_ADDRESSES`.
+### Deliverables
+Update the five files listed in the PR description; keep **all** invariants.
+Provide fully‑linted, production‑ready code. No partial snippets.
+
+/* What changed & why: Added Codex handoff section outlining dual-marketplace usage and v2a offline balance guard. Bumped to r10 on 2025-08-06. */

--- a/src/config/deployTarget.js
+++ b/src/config/deployTarget.js
@@ -1,12 +1,11 @@
 /*─────────────────────────────────────────────────────────────────
   Developed by @jams2blues – ZeroContract Studio
   File:    src/config/deployTarget.js
-  Rev :    r1158    2025‑08‑05
-  Summary: Corrected ghostnet marketplace address. Updated
-           MARKETPLACE_ADDRESSES to use KT1R1PzLhBXEd98ei72mFuz4FrUYEcuV7t1p for
-           ghostnet, fixing listing errors. Previous revision added
-           DOMAIN_CONTRACTS and FALLBACK_RPCS; other configuration
-           remains unchanged.
+  Rev :    r1162    2025‑08‑06
+  Summary: Split marketplace addresses into read/write arrays for
+           dual‑instance support. Exposes MARKETPLACE_WRITE_ADDRESSES
+           and MARKETPLACE_READ_ADDRESSES with legacy exports for
+           backward compatibility.
 */
 
 // ---------------------------------------------------------------------------
@@ -175,16 +174,26 @@ export const FACTORY_ADDRESS = FACTORY_ADDRESSES[TARGET];
 // network.  These values should be kept identical across branches, with
 // deployTarget.js remaining the sole diverging file between Ghostnet and
 // Mainnet.  See src/core/marketplace.js for usage.
-export const MARKETPLACE_ADDRESSES = {
+/*‐‐‐‐‐‐‐‐‐‐‐‐‐ Marketplace contracts ‐‐‐‐‐‐‐‐‐‐‐‐‐‐*/
+/* primary write‑target (new ZeroSum)                             */
+export const MARKETPLACE_WRITE_ADDRESSES = {
   ghostnet: 'KT19yn9fWP6zTSLPntGyrPwc7JuMHnYxAn1z',
   mainnet : 'KT19kipdLiWyBZvP7KWCPdRbDXuEiu3gfjBR',
 };
+/* read‑only historic instances                                   */
+export const MARKETPLACE_READ_ADDRESSES = {
+  ghostnet: [
+    MARKETPLACE_WRITE_ADDRESSES.ghostnet,         // always first
+    'KT1R1PzLhBXEd98ei72mFuz4FrUYEcuV7t1p',       // legacy
+  ],
+  mainnet: [
+    MARKETPLACE_WRITE_ADDRESSES.mainnet,          // only one so far
+  ],
+};
 
-// Selected marketplace address based on the active TARGET.  Use this
-// constant when you need the marketplace contract for a given network.
-// If no entry exists for a network, the value will be undefined and
-// calling code should handle that case appropriately.
-export const MARKETPLACE_ADDRESS = MARKETPLACE_ADDRESSES[TARGET];
+/* backward‑compat single address exports                         */
+export const MARKETPLACE_ADDRESS   = MARKETPLACE_WRITE_ADDRESSES[TARGET];
+export const MARKETPLACE_ADDRESSES = MARKETPLACE_READ_ADDRESSES; // <‑‑ keep original name for legacy imports
 
 // ---------------------------------------------------------------------------
 // Tezos Domain registry addresses and fallback RPCs
@@ -213,11 +222,6 @@ export const FALLBACK_RPCS = {
 // compatibility and avoid build errors we export a constant that
 // always resolves to an empty string.  Additional URLs could be
 // mapped per network if remote forging is ever reintroduced.
-const FORGE_URLS = {
-  ghostnet: '',
-  mainnet:  '',
-};
-
 // Deprecated: always returns an empty string.  Remote forge services are
 // permanently disabled; client code should fall back to local forging via
 // Taquito’s LocalForger.  This export is retained solely to satisfy

--- a/src/utils/getLedgerBalanceV2a.cjs
+++ b/src/utils/getLedgerBalanceV2a.cjs
@@ -1,40 +1,18 @@
 /*─────────────────────────────────────────────────────────────
 Developed by @jams2blues – ZeroContract Studio
 File:    src/utils/getLedgerBalanceV2a.cjs
-Rev :    r1    2025-08-10
-Summary: Direct ledger lookup for v2a contracts with 1-based token ids.
-         Attempts token_id and token_id+1 to fetch edition balance
-         from the ledger big_map.
-─────────────────────────────────────────────────────────────*/
-async function getLedgerBalanceV2a(toolkit, contract, pkh, id) {
-  try {
-    const tzkt = /ghostnet|limanet/i.test(toolkit.rpc.getRpcUrl?.() ?? '')
-      ? 'https://api.ghostnet.tzkt.io'
-      : 'https://api.tzkt.io';
-    const maps = await (await fetch(`${tzkt}/v1/contracts/${contract}/bigmaps`)).json();
-    const ledMap = maps.find((m) => m.path === 'ledger');
-    if (!ledMap) return { balance: 0, tokenId: undefined };
-    const mapId = ledMap.ptr ?? ledMap.id;
-    const attempt = async (tokenId) => {
-      const q = `${tzkt}/v1/bigmaps/${mapId}/keys?key.0=${pkh}&key.1=${tokenId}`;
-      const rows = await (await fetch(q)).json();
-      if (Array.isArray(rows) && rows.length > 0) {
-        return { balance: Number(rows[0]?.value ?? 0), tokenId };
-      }
-      return { balance: 0, tokenId: undefined };
-    };
-    // try provided token_id
-    let res = await attempt(id);
-    if (res.balance > 0) return res;
-    // try token_id - 1 (some v2a collections are 1-based)
-    res = await attempt(id - 1);
-    if (res.balance > 0) return res;
-    // finally try token_id + 1
-    res = await attempt(id + 1);
-    return res;
-  } catch {
-    return { balance: 0, tokenId: undefined };
-  }
-}
-module.exports = getLedgerBalanceV2a;
-/* What changed & why: return balance with resolved token_id and search token_id±1. */
+Rev :    r1    2025-08-06
+Summary: Simple TzKT balance fetch for v2a offline_balance guard.
+          Returns raw edition balance for a given owner and token.
+*/
+module.exports = async function getLedgerBalanceV2a(
+  { tzktBase, contract, tokenId, owner },
+) {
+  const url = `${tzktBase}/v1/tokens/balances` +
+              `?token.contract=${contract}&token.tokenId=${tokenId}` +
+              `&account=${owner}`;
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`TzKT ${res.status}`);
+  const [row] = await res.json();
+  return row ? Number(row.balance) : 0;
+};


### PR DESCRIPTION
### Summary
- document Codex handoff for dual marketplaces and offline balance checks
- separate read/write marketplace addresses and aggregate listings across instances
- add v2a TzKT balance util and UI guard with offline_balance flag

### Testing
- `npx eslint src/config/deployTarget.js src/core/marketplace.js src/utils/getLedgerBalanceV2a.cjs src/ui/ListTokenDialog.jsx __tests__/v2aLedger.test.js && echo "lint ok"`
- `yarn test`
- `yarn build`

### Progress-Ledger
| 1162 | ✔ | 6 | dual marketplace + v2a guard |


------
https://chatgpt.com/codex/tasks/task_e_6893c8f1665883308d65619068099def