### PR TITLE
Fix minting on v1 & v2b by correcting entrypoint call shapes

### DIFF
--- a/__tests__/exploreNav.regression.test.jsx
+++ b/__tests__/exploreNav.regression.test.jsx
@@ -1,3 +1,4 @@
+/* eslint-env jest */
 /*Developed by @jams2blues
   File: __tests__/ui/exploreNav.regression.test.jsx
   Rev:  r1

--- a/__tests__/mintCallShape.test.js
+++ b/__tests__/mintCallShape.test.js
@@ -1,0 +1,34 @@
+/* eslint-env jest */
+const { buildMintCall } = require('../src/ui/Entrypoints/mintCallShape.cjs');
+
+const mkC = () => ({ methods: { mint: jest.fn(() => ({ _tag: 'ok' })) } });
+
+test('v1 uses (map,to)', () => {
+  const c = mkC();
+  buildMintCall(c, 'v1', 1, 'MAP', 'TO');
+  expect(c.methods.mint).toHaveBeenCalledWith('MAP', 'TO');
+});
+
+test('v2a uses (n,map,to)', () => {
+  const c = mkC();
+  buildMintCall(c, 'v2a', 5, 'MAP', 'TO');
+  expect(c.methods.mint).toHaveBeenCalledWith(5, 'MAP', 'TO');
+});
+
+test('v2b uses (map,to)', () => {
+  const c = mkC();
+  buildMintCall(c, 'v2b', 1, 'MAP', 'TO');
+  expect(c.methods.mint).toHaveBeenCalledWith('MAP', 'TO');
+});
+
+test('v3 uses (n,map,to)', () => {
+  const c = mkC();
+  buildMintCall(c, 'v3', 2, 'MAP', 'TO');
+  expect(c.methods.mint).toHaveBeenCalledWith(2, 'MAP', 'TO');
+});
+
+test('v4a uses (to,n,map)', () => {
+  const c = mkC();
+  buildMintCall(c, 'v4a', 3, 'MAP', 'TO');
+  expect(c.methods.mint).toHaveBeenCalledWith('TO', 3, 'MAP');
+});

--- a/docs/Master_Overview_And_Manifest_zerounbound_contractmanagement.md
+++ b/docs/Master_Overview_And_Manifest_zerounbound_contractmanagement.md
@@ -324,6 +324,7 @@ I153 [F] **ExploreNav mandatory** — reaffirmed for all `explore/*` and `my/*` 
 I154 [F,E] **Tagged errors** — marketplace helpers surface actionable tags (`MISSING_LISTING_DETAILS`, `STALE_LISTING_NO_BALANCE`).
 I155 [I] **No sentinels in JS/JSX** — comment footers end with `*/` only.
 I156 [E] **Preflight budget & TTL** — balance checks observe jFetch limits; cache per `(seller,KT1,tokenId)` for ≤60 s (network‑scoped).
+I157 [C,E,F] **EP_MINT_SIGNATURES** — v1,v2b → mint(map,address); v2a,v3–v4e → mint(nat,map,address); v4a → mint(address,nat,map). Unit test asserts UI builds these shapes.
 
 ───────────────────────────────────────────────────────────────
 3 · RESERVED

--- a/src/config/deployTarget.js
+++ b/src/config/deployTarget.js
@@ -214,6 +214,7 @@ export const FALLBACK_RPCS = {
 // compatibility and avoid build errors we export a constant that
 // always resolves to an empty string.  Additional URLs could be
 // mapped per network if remote forging is ever reintroduced.
+// eslint-disable-next-line no-unused-vars
 const FORGE_URLS = {
   ghostnet: '',
   mainnet:  '',

--- a/src/data/entrypointRegistry.json
+++ b/src/data/entrypointRegistry.json
@@ -7,13 +7,13 @@
 
   "v1": {
     "$extends": "common",
-    "mint":  ["nat","map(string,bytes)","address"],
+    "mint":  ["map(string,bytes)","address"],
     "burn":  ["nat","nat"]
   },
 
   "v2a": {
     "$extends": "v1",
-    "mint":  ["map(string,bytes)","address"],
+    "mint":  ["nat","map(string,bytes)","address"],
     "burn":  ["nat"],
     "add_parent":  ["address"],
     "remove_parent": ["address"],
@@ -21,7 +21,7 @@
     "remove_child": ["address"],
     "lock_metadata": []
   },
-  "v2b": { "$extends": "v2a", "lock_metadata": false },
+  "v2b": { "$extends": "v2a", "mint": ["map(string,bytes)","address"], "lock_metadata": false },
   "v2c": { "$extends": "v2a", "lock_metadata": false },
   "v2d": { "$extends": "v2a", "lock_metadata": false },
   "v2e": { "$extends": "v2a", "lock_metadata": false },

--- a/src/ui/Entrypoints/mintCallShape.cjs
+++ b/src/ui/Entrypoints/mintCallShape.cjs
@@ -1,0 +1,13 @@
+/*──────── src/ui/Entrypoints/mintCallShape.cjs ────────*/
+/* Canonical mint call shapes per contract version */
+
+function buildMintCall(c, ver, amt, map, to) {
+  const v = String(ver || '').replace(/^v/i, '').toLowerCase();
+  const n = parseInt(amt, 10) || 1;
+  if (v === '4a') return c.methods.mint(to, n, map);
+  if (v === '1' || v === '2b') return c.methods.mint(map, to);
+  return c.methods.mint(n, map, to);
+}
+
+module.exports = { buildMintCall };
+/* EOF */


### PR DESCRIPTION
## Summary
- route v1/v2b mint calls through `(map,address)` while keeping editions for v2a/v3+/v4*
- sync entrypoint registry to on-chain signatures and add unit coverage
- document invariant I157 `EP_MINT_SIGNATURES`

## Testing
- `npx eslint src/ui/Entrypoints/Mint.jsx src/ui/Entrypoints/mintCallShape.cjs __tests__/mintCallShape.test.js __tests__/exploreNav.regression.test.jsx src/config/deployTarget.js`
- `yarn test __tests__/mintCallShape.test.js`
- `yarn build`

| rev | ✔ | files | outcome |
| r892 | ✔ | Mint.jsx, entrypointRegistry.json, docs | align mint signatures |


------
https://chatgpt.com/codex/tasks/task_e_68a61daa93388330873a5cb069202823