### PR TITLE
feat(codex): add slicer and idb cache

### DIFF
--- a/__tests__/sliceResume.test.js
+++ b/__tests__/sliceResume.test.js
@@ -1,0 +1,29 @@
+/* eslint-env jest */
+let planHead, cutTail, buildAppendCalls, countSlices;
+beforeAll(async () => {
+  ({ planHead, cutTail, buildAppendCalls } = await import('../src/core/slicing.js'));
+  ({ countSlices } = await import('../src/core/feeEstimator.js'));
+});
+
+const mkData = (n) => `data:text/plain,${'a'.repeat(n)}`;
+
+describe('slice resume', () => {
+  test('estimator matches builder', () => {
+    [8 * 1024, 40 * 1024, 138 * 1024].forEach((size) => {
+      const data = mkData(size);
+      const { expectedSlices } = countSlices(data);
+      const { remainingHex } = planHead(data);
+      const calls = buildAppendCalls({ contract: 'KT1', tokenId: 0, tailHex: remainingHex });
+      expect(expectedSlices).toBe(1 + calls.length);
+    });
+  });
+
+  test('resume produces exact tail', () => {
+    const data = mkData(10 * 1024);
+    const { headStr } = planHead(data);
+    const prefix = headStr.slice(0, headStr.length - 20);
+    const tailHex = cutTail({ fullStr: data, onChainPrefixStr: prefix });
+    const rebuilt = prefix + Buffer.from(tailHex, 'hex').toString('utf8');
+    expect(rebuilt).toBe(data);
+  });
+});

--- a/__tests__/svgDataUri.test.js
+++ b/__tests__/svgDataUri.test.js
@@ -1,0 +1,30 @@
+/* eslint-env jest */
+let planHead, cutTail, buildAppendCalls, ensureDataUri, isLikelySvg;
+beforeAll(async () => {
+  ({ planHead, cutTail, buildAppendCalls } = await import('../src/core/slicing.js'));
+  ({ ensureDataUri, isLikelySvg } = await import('../src/utils/uriHelpers.js'));
+});
+
+const svg = '<svg xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10"/></svg>';
+
+const bigSvg = `<svg xmlns="http://www.w3.org/2000/svg">${'<g></g>'.repeat(5000)}</svg>`;
+
+describe('svg data uri', () => {
+  test('round trip small svg', () => {
+    const du = ensureDataUri(`data:image/svg+xml;utf8,${svg}`);
+    expect(isLikelySvg(svg)).toBe(true);
+    const { headStr } = planHead(du);
+    const tailHex = cutTail({ fullStr: du, onChainPrefixStr: headStr });
+    const calls = buildAppendCalls({ contract: 'KT1', tokenId: 0, tailHex });
+    const rebuilt = headStr + Buffer.from(tailHex, 'hex').toString('utf8');
+    expect(rebuilt).toBe(du);
+    expect(Array.isArray(calls)).toBe(true);
+  });
+
+  test('large svg generates calls', () => {
+    const du = ensureDataUri(`data:image/svg+xml;utf8,${bigSvg}`);
+    const { remainingHex } = planHead(du);
+    const calls = buildAppendCalls({ contract: 'KT1', tokenId: 0, tailHex: remainingHex });
+    expect(calls.length).toBeGreaterThan(0);
+  });
+});

--- a/docs/Master_Overview_And_Manifest_zerounbound_contractmanagement.md
+++ b/docs/Master_Overview_And_Manifest_zerounbound_contractmanagement.md
@@ -1,8 +1,8 @@
 /*─────────────────────────────────────────────────────────────────
   Developed by @jams2blues – ZeroContract Studio
   File:    docs/Master_Overview_And_Manifest_zerounbound_contractmanagement.md
-  Rev :    r1183    2025‑09‑07 UTC
-  Summary: canonical slicer, IDB‑only slice cache, and data‑URI tests.
+  Rev :    r1185    2025‑09‑07 UTC
+  Summary: canonical slicer, IDB‑only slice cache, data‑URI tests, and RPC-backed extrauri view.
 ──────────────────────────────────────────────────────────────────*/
 
 ════════════════════════════════════════════════════════════════
@@ -478,7 +478,7 @@ zerounbound/src/pages/my/tokens.jsx — minted/owned discovery; live‑balance f
 
 — contracts/tokens —
 zerounbound/src/pages/contracts/[addr].jsx — collection detail; Imports: ContractMetaPanelContracts,TokenCard,hazards; Exports: ContractPage
-zerounbound/src/pages/tokens/[addr]/[tokenId].jsx — token detail; integrates MAINTokenMetaPanel, extrauri viewer with prev/next navigation & hazard overlays; Exports: TokenDetailPage
+zerounbound/src/pages/tokens/[addr]/[tokenId].jsx — token detail; integrates MAINTokenMetaPanel, extrauri viewer with prev/next navigation & hazard overlays; fetches get_extrauris via RPC (tzip16) with TzKT fallback; Exports: TokenDetailPage
 
 ╭── src/styles ──────────────────────────────────────────────────────────────╮
 zerounbound/src/styles/globalStyles.js — root CSS + scrollbar; Imports: styled‑components,palettes.json; Exports: GlobalStyles
@@ -673,6 +673,7 @@ Why the delineation matters: AdminTools introspects the typeHash → version to 
 ───────────────────────────────────────────────────────────────
 CHANGELOG
 ───────────────────────────────────────────────────────────────
+r1185 — Token detail page fetches get_extrauris via RPC (tzip16) with TzKT fallback, removing Better Call Dev dependency.
 r1184 — Add extrauri viewer with navigation and downloadable MIME links on token detail page.
 r1183 — Introduce canonical slicer, migrate slice checkpoints to IndexedDB only, add data‑URI tests.
 r1182 — Document marketplace dialogs (Buy/List/MakeOffer) and
@@ -684,4 +685,4 @@ normalization, reaffirm listings stale‑listing guard & transient‑prop rule.
 r1180 — Add ZeroSum stale‑listing guard based on TzKT balances,
 enforce /v1 base normalization, codify transient‑prop rule, reaffirm no‑sentinel.
 
-/* What changed & why: Added extrauri viewer with navigation and downloadable MIME links; appended changelog. */
+/* What changed & why: Token page now calls get_extrauris via RPC (tzip16) with TzKT fallback, removing BCD dependency; appended changelog. */

--- a/docs/Master_Overview_And_Manifest_zerounbound_contractmanagement.md
+++ b/docs/Master_Overview_And_Manifest_zerounbound_contractmanagement.md
@@ -478,7 +478,7 @@ zerounbound/src/pages/my/tokens.jsx — minted/owned discovery; live‑balance f
 
 — contracts/tokens —
 zerounbound/src/pages/contracts/[addr].jsx — collection detail; Imports: ContractMetaPanelContracts,TokenCard,hazards; Exports: ContractPage
-zerounbound/src/pages/tokens/[addr]/[tokenId].jsx — token detail; integrates MAINTokenMetaPanel & hazard overlays; Exports: TokenDetailPage
+zerounbound/src/pages/tokens/[addr]/[tokenId].jsx — token detail; integrates MAINTokenMetaPanel, extrauri viewer with prev/next navigation & hazard overlays; Exports: TokenDetailPage
 
 ╭── src/styles ──────────────────────────────────────────────────────────────╮
 zerounbound/src/styles/globalStyles.js — root CSS + scrollbar; Imports: styled‑components,palettes.json; Exports: GlobalStyles
@@ -500,6 +500,7 @@ zerounbound/src/ui/ThemeToggle.jsx — palette switch button; Exports: ThemeTogg
 zerounbound/src/ui/WalletNotice.jsx — wallet status banner; Exports: WalletNotice
 zerounbound/src/ui/ZerosBackground.jsx — animated zeros field; Exports: ZerosBackground
 zerounbound/src/ui/IntegrityBadge.jsx — on‑chain integrity badge; Exports: IntegrityBadge
+zerounbound/src/ui/MAINTokenMetaPanel.jsx — token detail meta panel with extrauri navigation & downloadable MIME links; Imports: RenderMedia, hazards; Exports: MAINTokenMetaPanel
 
 — marketplace bars & dialogs —
 zerounbound/src/ui/BuyDialog.jsx — buy modal; Imports: buildBuyParams,preflightBuy; Exports: BuyDialog
@@ -672,6 +673,7 @@ Why the delineation matters: AdminTools introspects the typeHash → version to 
 ───────────────────────────────────────────────────────────────
 CHANGELOG
 ───────────────────────────────────────────────────────────────
+r1184 — Add extrauri viewer with navigation and downloadable MIME links on token detail page.
 r1183 — Introduce canonical slicer, migrate slice checkpoints to IndexedDB only, add data‑URI tests.
 r1182 — Document marketplace dialogs (Buy/List/MakeOffer) and
 Accept/Cancel entrypoints; extend manifest coverage for completeness.
@@ -682,4 +684,4 @@ normalization, reaffirm listings stale‑listing guard & transient‑prop rule.
 r1180 — Add ZeroSum stale‑listing guard based on TzKT balances,
 enforce /v1 base normalization, codify transient‑prop rule, reaffirm no‑sentinel.
 
-/* What changed & why: Introduced canonical slicer and IDB-only checkpoints; updated manifest and invariants accordingly. */
+/* What changed & why: Added extrauri viewer with navigation and downloadable MIME links; appended changelog. */

--- a/docs/Master_Overview_And_Manifest_zerounbound_contractmanagement.md
+++ b/docs/Master_Overview_And_Manifest_zerounbound_contractmanagement.md
@@ -586,8 +586,8 @@ zerounbound/src/utils/onChainValidator.js — fast FOC heuristic (I99); Exports:
 zerounbound/src/utils/pixelUpscale.js — css helpers for pixel‑art upscaling; Exports: pixelUpscaleStyle
 zerounbound/src/utils/RenderMedia.jsx — data‑URI media viewer; Exports: RenderMedia
 zerounbound/src/utils/resolveTezosDomain.js — reverse resolver; imports DOMAIN_CONTRACTS/FALLBACK_RPCS; Exports: resolveTezosDomain
-zerounbound/src/utils/sliceCache.js — localStorage cache (legacy; not used by discovery); Exports: saveSlice,loadSlice,purgeExpired
-zerounbound/src/utils/sliceCacheV4a.js — v4a slice cache; Exports: saveSliceCheckpoint,loadSliceCheckpoint,clearSliceCheckpoint,purgeExpiredSliceCache,strHash
+zerounbound/src/utils/sliceCache.js — IndexedDB slice checkpoint cache; Exports: saveSliceCheckpoint,loadSliceCheckpoint,clearSliceCheckpoint,purgeExpiredSliceCache
+zerounbound/src/utils/sliceCacheV4a.js — v4a slice cache (IndexedDB); Exports: saveSliceCheckpoint,loadSliceCheckpoint,clearSliceCheckpoint,purgeExpiredSliceCache,strHash
 zerounbound/src/utils/toNat.js — address→nat util; Exports: toNat
 zerounbound/src/utils/uriHelpers.js — data‑URI helpers; Exports: ensureDataUri,getMime
 zerounbound/src/utils/useIsoLayoutEffect.js — SSR‑safe layout effect; Exports: useIsoLayoutEffect

--- a/docs/TZIP_Compliance_Invariants_ZeroContract_V4.md
+++ b/docs/TZIP_Compliance_Invariants_ZeroContract_V4.md
@@ -98,6 +98,9 @@ Implementations MAY provide resume support if desired: if the origination fails
 after signing but before confirmation, the UI should persist the contract address
 and metadata JSON in localStorage and allow the user to retry.
 
+Slice checkpoints for oversized uploads are now stored in IndexedDB only;
+legacy localStorage paths must be migrated on first access.
+
 ──────────────────────────────────────────────────────────────────────────────
 /* What changed & why: Updated to r6. Removed dual‑stage origination guidance
 and remote forge service references; clarified that the full metadata,

--- a/docs/TZIP_Compliance_Invariants_ZeroContract_V4.md
+++ b/docs/TZIP_Compliance_Invariants_ZeroContract_V4.md
@@ -2,8 +2,8 @@
 /─────────────────────────────────────────────────────────────────
 Developed by @jams2blues – ZeroContract Studio
 File: docs/TZIP_Compliance_Invariants_ZeroContract_V4.md
-Rev : r6 2025-07-24 UTC
-Summary: update metadata invariants for single‑stage origination and remove dual‑stage guidance.
+Rev : r7 2025-09-07 UTC
+Summary: add canonical slicing + IDB-only checkpoints; reinforce diff-aware append rules.
 ──────────────────────────────────────────────────────────────/
 
 TZIP_Compliance_Invariants_ZeroContract_V4.md
@@ -101,8 +101,13 @@ and metadata JSON in localStorage and allow the user to retry.
 Slice checkpoints for oversized uploads are now stored in IndexedDB only;
 legacy localStorage paths must be migrated on first access.
 
+All append/repair flows must recompute the on-chain artifactUri prefix after
+each confirmed slice using the canonical slicer to prevent duplicate bytes.
+The fee estimator and batch builder share this module so expected signature
+counts match wallet prompts. Data URIs must pass `isValidDataUri`/`isLikelySvg`
+checks before slicing; malformed payloads are rejected.
+
 ──────────────────────────────────────────────────────────────────────────────
-/* What changed & why: Updated to r6. Removed dual‑stage origination guidance
-and remote forge service references; clarified that the full metadata,
-including the views array and imageUri, is stored during a single‑stage
-origination. Other sections are unchanged from the previous revision. */
+/* What changed & why: Updated to r7. Added canonical slicer rules,
+IndexedDB-only checkpoint note, and data-URI validation guidance. Other sections
+remain unchanged. */

--- a/docs/TZIP_Compliance_Invariants_ZeroContract_V4.md
+++ b/docs/TZIP_Compliance_Invariants_ZeroContract_V4.md
@@ -107,7 +107,8 @@ The fee estimator and batch builder share this module so expected signature
 counts match wallet prompts. Data URIs must pass `isValidDataUri`/`isLikelySvg`
 checks before slicing; malformed payloads are rejected.
 
+Tokens with `extrauri_*` metadata MUST expose those assets via the `get_extrauris` view. UIs MUST provide navigation across all returned items and offer a MIME‑accurate download link for each value.
+
 ──────────────────────────────────────────────────────────────────────────────
 /* What changed & why: Updated to r7. Added canonical slicer rules,
-IndexedDB-only checkpoint note, and data-URI validation guidance. Other sections
-remain unchanged. */
+IndexedDB-only checkpoint note, data-URI validation guidance, and extrauri viewer requirement. Other sections remain unchanged. */

--- a/src/core/batch.js
+++ b/src/core/batch.js
@@ -6,11 +6,9 @@
 ──────────────────────────────────────────────────────────────*/
 import { OpKind } from '@taquito/taquito';
 import { HARD_STORAGE_LIMIT } from './feeEstimator.js';
+import { SLICE_MAX_BYTES, PACKED_SAFE_BYTES } from './slicing.js';
+export { SLICE_MAX_BYTES, SLICE_MIN_BYTES, PACKED_SAFE_BYTES } from './slicing.js';
 
-/*────────────────── public constants ──────────────────*/
-export const SLICE_MAX_BYTES   = 20_000;   /* optimistic start */
-export const SLICE_MIN_BYTES   = 1_024;    /* fallback min */
-export const PACKED_SAFE_BYTES = 31_000;   /* bytes per op-pack */
 const SLICE_OVERHEAD = 512;                /* Michelson/encoding padding */
 const OP_SIZE_OVERHEAD = 200;              /* forged bytes per op */
 

--- a/src/core/feeEstimator.js
+++ b/src/core/feeEstimator.js
@@ -6,6 +6,7 @@
 ──────────────────────────────────────────────────────────────*/
 import { OpKind } from '@taquito/taquito';
 import { Buffer } from 'buffer';
+import { planHead, buildAppendCalls } from './slicing.js';
 
 /*──────── chain‑wide constants ─────────────────────────────*/
 export const MINIMAL_FEE_MUTEZ         = 100;     /* base per op */
@@ -29,6 +30,14 @@ const PACKING_OVERHEAD            = 50;       /* per-batch packing est */
 
 /*──────── unit helpers ─────────────────────────────────────*/
 export const toTez = (m = 0) => (m / 1_000_000).toFixed(6);
+
+/*──────── slice counter ─────────────────────────────────────*/
+export function countSlices(dataUri = '') {
+  const { remainingHex } = planHead(dataUri);
+  const calls = buildAppendCalls({ contract: '', tokenId: 0, tailHex: remainingHex });
+  const total = 1 + calls.length;
+  return { expectedSlices: total, expectedSignatures: total };
+}
 
 /*──────── storage‑burn calculator ──────────────────────────*/
 /**

--- a/src/core/slicing.js
+++ b/src/core/slicing.js
@@ -1,0 +1,89 @@
+/*─────────────────────────────────────────────────────────────
+  Developed by @jams2blues – ZeroContract Studio
+  File:    src/core/slicing.js
+  Rev :    r1 2025-09-07
+  Summary: canonical head/tail slicer and diff helpers
+──────────────────────────────────────────────────────────────*/
+import { bytes2Char } from '@taquito/utils';
+
+/*──────── constants ─────*/
+export const SLICE_MAX_BYTES   = 20_000;         /* optimistic default */
+export const SLICE_MIN_BYTES   = 1_024;          /* minimum slice bytes */
+export const PACKED_SAFE_BYTES = 31_000;         /* safe pack size */
+export const HEADROOM_BYTES    = 512;            /* overhead headroom */
+
+/*──────── helpers ─────*/
+const bufFrom = (str='') => Buffer.from(str, 'utf8');
+const hexOf   = (buf)   => buf.toString('hex');
+
+/**
+ * planHead(dataUri)
+ * Splits a data URI into an initial head (utf8 string) that fits within
+ * SLICE_MAX_BYTES while leaving HEADROOM_BYTES for Michelson overhead.
+ */
+export function planHead(dataUri='') {
+  const fullBuf   = bufFrom(dataUri);
+  const totalBytes= fullBuf.length;
+  const headBytes = Math.min(totalBytes, SLICE_MAX_BYTES - HEADROOM_BYTES);
+  const headBuf   = fullBuf.slice(0, headBytes);
+  const tailBuf   = fullBuf.slice(headBytes);
+  return {
+    headStr: headBuf.toString('utf8'),
+    headBytes,
+    headHex: hexOf(headBuf),
+    remainingHex: hexOf(tailBuf),
+    totalBytes,
+  };
+}
+
+/**
+ * computeOnChainPrefix({ tzktBase, contract, tokenId })
+ * Fetches current artifactUri from TzKT and returns as a string.
+ */
+export async function computeOnChainPrefix({ tzktBase, contract, tokenId }) {
+  const url = `${tzktBase}/tokens?contract=${contract}&tokenId=${tokenId}&limit=1`;
+  try {
+    const rows = await (await fetch(url)).json();
+    let art = rows?.[0]?.metadata?.artifactUri || '';
+    if (art && /^0x[0-9a-fA-F]+$/.test(art)) art = bytes2Char(art);
+    return String(art || '');
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * cutTail({ fullStr, onChainPrefixStr })
+ * Returns hex tail from first differing byte. Throws on mismatch.
+ */
+export function cutTail({ fullStr='', onChainPrefixStr='' }) {
+  const fullBuf   = bufFrom(fullStr);
+  const prefixBuf = bufFrom(onChainPrefixStr);
+  const len = Math.min(fullBuf.length, prefixBuf.length);
+  let i = 0;
+  for (; i < len && fullBuf[i] === prefixBuf[i]; i++);
+  if (i < prefixBuf.length && prefixBuf.slice(0, i).length !== prefixBuf.length) {
+    throw new Error('on-chain prefix mismatch');
+  }
+  const tail = fullBuf.slice(prefixBuf.length);
+  return tail.length ? hexOf(tail) : '';
+}
+
+/**
+ * buildAppendCalls({ contract, tokenId, tailHex, packBudget })
+ * Splits tailHex into <= SLICE_MAX_BYTES slices and returns call objects
+ * for append_artifact_uri.
+ */
+export function buildAppendCalls({ contract, tokenId, tailHex='', packBudget = PACKED_SAFE_BYTES }) {
+  void packBudget; // reserved for future packing heuristics
+  const hx = tailHex.startsWith('0x') ? tailHex.slice(2) : tailHex;
+  const out = [];
+  const step = SLICE_MAX_BYTES * 2;
+  for (let i = 0; i < hx.length; i += step) {
+    const slice = hx.slice(i, i + step);
+    out.push({ method: 'append_artifact_uri', args: [tokenId, `0x${slice}`], contract });
+  }
+  return out;
+}
+
+/* EOF */

--- a/src/hooks/useTxEstimate.js
+++ b/src/hooks/useTxEstimate.js
@@ -56,6 +56,8 @@ const fallbackCosts = (opsLen = 1) => {
   return {
     feeTez:     toTez(feeMutez),
     storageTez: '0',
+    expectedSlices: opsLen,
+    expectedSignatures: opsLen,
     isLoading:  false,
     isInsufficient: false,
     error: null,
@@ -128,6 +130,8 @@ export default function useTxEstimate(toolkit, params) {
         setState({
           feeTez: toTez(feeMutez),
           storageTez: toTez(storageMutez),
+          expectedSlices: params.length,
+          expectedSignatures: params.length,
           isLoading: false,
           isInsufficient: feeMutez + storageMutez > balance.toNumber(),
           error: null,

--- a/src/pages/tokens/[addr]/[tokenId].jsx
+++ b/src/pages/tokens/[addr]/[tokenId].jsx
@@ -173,17 +173,25 @@ export default function TokenDetailPage() {
             if (toolkit) {
               try { toolkit.addExtension?.(new Tzip16Module()); } catch {}
               const contract = await toolkit.contract.at(addr, tzip16);
-              const viewResult = await contract.metadataViews.get_extrauris(tokenId).executeView();
-              if (viewResult && typeof viewResult === 'object') {
-                const entries = viewResult.entries ? viewResult.entries() : Object.entries(viewResult);
-                for (const [, value] of entries) {
-                  if (value && typeof value === 'object') {
-                    extras.push({
-                      description: value.description,
-                      key       : value.key,
-                      name      : value.name,
-                      value     : value.value,
-                    });
+              const views = typeof contract.metadataViews === 'function'
+                ? await contract.metadataViews()
+                : contract.metadataViews;
+              const fn = views?.get_extrauris;
+              if (typeof fn === 'function') {
+                const viewResult = await fn(tokenId).executeView();
+                if (viewResult && typeof viewResult === 'object') {
+                  const entries = viewResult.entries
+                    ? viewResult.entries()
+                    : Object.entries(viewResult);
+                  for (const [, value] of entries) {
+                    if (value && typeof value === 'object') {
+                      extras.push({
+                        description: value.description,
+                        key       : value.key,
+                        name      : value.name,
+                        value     : value.value,
+                      });
+                    }
                   }
                 }
               }

--- a/src/pages/tokens/[addr]/[tokenId].jsx
+++ b/src/pages/tokens/[addr]/[tokenId].jsx
@@ -28,7 +28,6 @@ import { jFetch } from '../../../core/net.js';
 import { TZKT_API, NETWORK_KEY } from '../../../config/deployTarget.js';
 import decodeHexFields, { decodeHexJson } from '../../../utils/decodeHexFields.js';
 import { mimeFromDataUri } from '../../../utils/uriHelpers.js';
-import { TezosToolkit } from '@taquito/taquito';
 import { Tzip16Module, tzip16 } from '@taquito/tzip16';
 
 /*──────────────── helpers ───────────────────────────────────────────*/
@@ -174,7 +173,7 @@ export default function TokenDetailPage() {
             if (toolkit) {
               try { toolkit.addExtension?.(new Tzip16Module()); } catch {}
               const contract = await toolkit.contract.at(addr, tzip16);
-              const viewResult = await contract.views.get_extrauris(tokenId).executeView();
+              const viewResult = await contract.metadataViews.get_extrauris(tokenId).executeView();
               if (viewResult && typeof viewResult === 'object') {
                 const entries = viewResult.entries ? viewResult.entries() : Object.entries(viewResult);
                 for (const [, value] of entries) {

--- a/src/pages/tokens/[addr]/[tokenId].jsx
+++ b/src/pages/tokens/[addr]/[tokenId].jsx
@@ -200,9 +200,11 @@ export default function TokenDetailPage() {
             // Fallback to TzKT view runner if RPC method fails or returns empty.
             if (!extras.length) {
               const viewBase = `${apiBase}/contracts/${addr}/views/get_extrauris`;
-              const tzktResult = await jFetch(
-                `${viewBase}?input=${tokenId}&unlimited=true&format=json`,
-              ).catch(() => []);
+              const tzktResult = await jFetch(viewBase, 1, {
+                method : 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body   : JSON.stringify({ input: Number(tokenId), unlimited: true, format: 'json' }),
+              }).catch(() => []);
               if (Array.isArray(tzktResult)) extras = tzktResult;
             }
 

--- a/src/ui/Entrypoints/Mint.jsx
+++ b/src/ui/Entrypoints/Mint.jsx
@@ -614,7 +614,7 @@ export default function Mint({
 
       for (let i = 0; i < amt; i += 1) {
         const tokenId = baseId + i;
-        const cp = loadSliceCheckpoint(contractAddress, tokenId, 'artifactUri') || {};
+        const cp = await loadSliceCheckpoint(contractAddress, tokenId, 'artifactUri') || {};
         const startSlice = cp.next ?? 1;                  // 1‑based index
         for (let s = startSlice; s <= appendSlices.length; s += 1) {
           const hx = appendSlices[s - 1];
@@ -625,7 +625,7 @@ export default function Mint({
         }
 
         /* persist / update checkpoint */
-        saveSliceCheckpoint(contractAddress, tokenId, 'artifactUri', {
+        await saveSliceCheckpoint(contractAddress, tokenId, 'artifactUri', {
           total: appendSlices.length + 1,
           next: startSlice,
           hash: cp.hash || `sha256:${digest}`,
@@ -656,7 +656,7 @@ export default function Mint({
       try {
         const tokenId = Number(first.value.args[0].int);
         const hx      = `0x${first.value.args[1].bytes}`;
-        const cp      = loadSliceCheckpoint(contractAddress, tokenId, 'artifactUri');
+        const cp      = await loadSliceCheckpoint(contractAddress, tokenId, 'artifactUri');
         const already = cp && appendSlices.findIndex((s) => s === hx) < (cp.next ?? 1) - 1;
         if (!already) break;     /* needs to send */
       } catch { break; }         /* parse failure → just send */
@@ -692,10 +692,10 @@ export default function Mint({
       if (first?.entrypoint === 'append_artifact_uri') {
         try {
           const tokenId = Number(first.value.args[0].int);
-          const cp = loadSliceCheckpoint(contractAddress, tokenId, 'artifactUri');
+          const cp = await loadSliceCheckpoint(contractAddress, tokenId, 'artifactUri');
           if (cp) {
             const next = Math.min(cp.next + 1, cp.total);
-            saveSliceCheckpoint(contractAddress, tokenId, 'artifactUri', { ...cp, next });
+            await saveSliceCheckpoint(contractAddress, tokenId, 'artifactUri', { ...cp, next });
           }
         } catch {/* ignore parse errors */}
       }

--- a/src/ui/Entrypoints/RepairUriV4a.jsx
+++ b/src/ui/Entrypoints/RepairUriV4a.jsx
@@ -320,11 +320,16 @@ export default function RepairUriV4a({
         requestAnimationFrame(() => runSlice(idx + 1));
       } else {
         await clearSliceCheckpoint(...checkpointArgs);
-        setOverlay({ open:false });
-        setBatches(null);
         setResumeInfo(null);
+        setBatches(null);
         snack('Repair complete', 'success');
         onMutate();
+        setOverlay({
+          open: true,
+          opHash: op.opHash,
+          current: batches.length,
+          total: batches.length,
+        });
       }
     } catch (e) {
       setOverlay({ open:true, error:true,

--- a/src/ui/FullscreenModal.jsx
+++ b/src/ui/FullscreenModal.jsx
@@ -71,6 +71,13 @@ const CloseWrap = styled.div`
   z-index: ${TOPMOST_Z + 2};
 `;
 
+const NavBtn = styled(PixelButton)`
+  position: fixed;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: ${TOPMOST_Z + 2};
+`;
+
 /* ephemeral helper badge */
 const Hint = styled.div`
   position: fixed;
@@ -160,6 +167,10 @@ export default function FullscreenModal({
   hideControlsDefault = false,
   lockControlsHidden  = false,
   showHint            = true,
+  hasPrev             = false,
+  hasNext             = false,
+  onPrev              = () => {},
+  onNext              = () => {},
 }) {
   const [nat, setNat]          = useState({ w: 0, h: 0 });
   const [scale, setScale]      = useState(1);
@@ -379,6 +390,17 @@ export default function FullscreenModal({
       {hintVisible && !lockControlsHidden && (
         <Hint>H — hide controls · two‑finger tap/long‑press on mobile</Hint>
       )}
+
+      {hasPrev && uiVisible && (
+        <NavBtn style={{ left: '.75rem' }} onClick={onPrev} aria-label="Previous">
+          ◀
+        </NavBtn>
+      )}
+      {hasNext && uiVisible && (
+        <NavBtn style={{ right: '.75rem' }} onClick={onNext} aria-label="Next">
+          ▶
+        </NavBtn>
+      )}
     </Back>
   );
 }
@@ -393,6 +415,10 @@ FullscreenModal.propTypes = {
   hideControlsDefault : PropTypes.bool,
   lockControlsHidden  : PropTypes.bool,
   showHint            : PropTypes.bool,
+  hasPrev             : PropTypes.bool,
+  hasNext             : PropTypes.bool,
+  onPrev              : PropTypes.func,
+  onNext              : PropTypes.func,
 };
 
 /* What changed & why (r16):

--- a/src/utils/idbCache.js
+++ b/src/utils/idbCache.js
@@ -7,6 +7,7 @@
 
 const DB_NAME = 'ZeroUnboundCache';
 const STORE_NAME = 'KeyValueStore';
+const DB_VERSION = 2;
 
 let dbPromise = null;
 
@@ -16,9 +17,12 @@ function getDb() {
   }
   if (!dbPromise) {
     dbPromise = new Promise((resolve, reject) => {
-      const request = indexedDB.open(DB_NAME, 1);
+      const request = indexedDB.open(DB_NAME, DB_VERSION);
       request.onupgradeneeded = () => {
-        request.result.createObjectStore(STORE_NAME);
+        const { result } = request;
+        if (!result.objectStoreNames.contains(STORE_NAME)) {
+          result.createObjectStore(STORE_NAME);
+        }
       };
       request.onsuccess = () => resolve(request.result);
       request.onerror = () => reject(request.error);

--- a/src/utils/sliceCache.js
+++ b/src/utils/sliceCache.js
@@ -1,173 +1,71 @@
-/*Developed by @jams2blues – ZeroContract Studio
+/*─────────────────────────────────────────────────────────────
+  Developed by @jams2blues – ZeroContract Studio
   File:    src/utils/sliceCache.js
-  Rev :    r707   2025-06-13
-  Summary: drop legacy duplicate block; keep single I60/I61-compliant
-           implementation with back-compat shims.
-─────────────────────────────────────────────────────────────*/
+  Rev :    r1 2025-09-07
+  Summary: IndexedDB-only slice checkpoint cache
+──────────────────────────────────────────────────────────────*/
+import { get as idbGet, set as idbSet, del as idbDel } from './idbCache.js';
 
-const PREFIX       = 'zuSliceCache';          /* localStorage key-root     */
-const CHUNK_SIZE   = 32_768;                  /* raw-bytes per slice       */
-const BYTES_MAX    = 5 * 1024 * 1024;         /* 5 MB hard cap             */
-const BYTES_TARGET = 4 * 1024 * 1024;         /* shrink-to size on flush   */
-const DAY_MS       = 86_400_000;              /* 24 h                      */
+const PREFIX = 'zu:slice';
+const detectNet = () => (typeof window === 'undefined' ? 'ghostnet' : (/ghostnet/i.test(window.location.hostname) ? 'ghostnet' : 'mainnet'));
 
-/*──────── helpers ───────────────────────────────────────────*/
+const keyOf = (net, contract, tokenId) => `${PREFIX}:${net}:${contract}:${tokenId}`;
 
-/** Return `"ghostnet"` | `"mainnet"` by hostname. */
-function detectNet () {
-  if (typeof window === 'undefined') return 'ghostnet';
-  return /ghostnet/i.test(window.location.hostname) ? 'ghostnet' : 'mainnet';
-}
-
-/** Build composite storage key. */
-function keyOf (net, contract, tokenId, label = 'artifact') {
-  return `${PREFIX}:${net}:${contract}:${tokenId}:${label}`;
-}
-
-/** Async SHA-256 digest → hex. */
-async function sha256Hex (txt = '') {
-  const buf  = new TextEncoder().encode(txt);
-  const hash = await crypto.subtle.digest('SHA-256', buf);
-  return Array.from(new Uint8Array(hash))
-    .map((b) => b.toString(16).padStart(2, '0'))
-    .join('');
-}
-
-/*──────── size helpers ─────────────────────────────────────*/
-
-function cacheBytes () {
-  let n = 0;
-  for (const k in localStorage) {
-    if (k.startsWith(PREFIX)) n += k.length + localStorage.getItem(k).length;
-  }
-  return n;
-}
-
-function shrinkCache () {
-  let total = cacheBytes();
-  if (total <= BYTES_MAX) return;
-
-  const items = [];
-  for (const k in localStorage) {
-    if (!k.startsWith(PREFIX)) continue;
-    try {
-      const { updated = 0 } = JSON.parse(localStorage.getItem(k) || '{}');
-      items.push({ k, updated });
-    } catch { localStorage.removeItem(k); }
-  }
-  items.sort((a, b) => a.updated - b.updated);       /* oldest first */
-  for (const { k } of items) {
-    localStorage.removeItem(k);
-    total = cacheBytes();
-    if (total <= BYTES_TARGET) break;
-  }
-}
-
-/*──────── core API ─────────────────────────────────────────*/
-
-/**
- * Load checkpoint or null.
- * @returns {object|null}
- */
-export function loadSliceCheckpoint (
-  contract,
-  tokenId,
-  label = 'artifact',
-  net   = detectNet(),
-) {
+async function migrateLocal(contract, tokenId, label, net) {
+  if (typeof localStorage === 'undefined') return null;
+  const oldKey = `zuSliceCache:${net}:${contract}:${tokenId}:${label}`;
+  const raw = localStorage.getItem(oldKey);
+  if (!raw) return null;
   try {
-    const raw = localStorage.getItem(keyOf(net, contract, tokenId, label));
-    return raw ? JSON.parse(raw) : null;
-  } catch { return null; }
-}
-
-/**
- * Persist / merge checkpoint (idempotent).
- * `info` may supply either `next` or legacy `nextIdx`.
- */
-export function saveSliceCheckpoint (
-  contract,
-  tokenId,
-  label,
-  info,
-  net = detectNet(),
-) {
-  try {
-    const now = Date.now();
+    const obj = JSON.parse(raw);
     const rec = {
-      tokenId : +tokenId,
-      label,
-      chunkSize: CHUNK_SIZE,
-      updated  : now,
-      ...info,
+      tokenKey: `${net}/${contract}/${tokenId}`,
+      lastConfirmedBytes: obj.next || 0,
+      headBytes: obj.headBytes || 0,
+      expectedTotalBytes: obj.total || 0,
+      sha256Head: obj.sha256Head || '',
+      sha256Full: obj.hash || '',
+      lastOpHash: obj.lastOpHash || '',
+      createdAt: obj.created || Date.now(),
+      updatedAt: obj.updated || Date.now(),
     };
-    if (rec.next == null && rec.nextIdx != null) rec.next = rec.nextIdx;
-    localStorage.setItem(
-      keyOf(net, contract, tokenId, label),
-      JSON.stringify(rec),
-    );
-    shrinkCache();
-  } catch {/* quota / private-mode – ignore */}
+    await idbSet(keyOf(net, contract, tokenId), rec);
+    localStorage.removeItem(oldKey);
+    return rec;
+  } catch {
+    return null;
+  }
 }
 
-/** Delete checkpoint. */
-export function clearSliceCheckpoint (
-  contract,
-  tokenId,
-  label = 'artifact',
-  net   = detectNet(),
-) {
-  try { localStorage.removeItem(keyOf(net, contract, tokenId, label)); } catch {}
+export async function loadSliceCheckpoint(contract, tokenId, label='artifactUri', net=detectNet()) {
+  const k = keyOf(net, contract, tokenId);
+  let row = await idbGet(k);
+  if (!row) row = await migrateLocal(contract, tokenId, label, net);
+  return row || null;
 }
 
-/*──────── hygiene (I61) ────────────────────────────────────*/
-
-/**
- * Non-blocking purge – runs in micro-task.
- *  • updated ≥ 24 h
- *  • total === 0
- *  • hash mismatch
- *  • global size cap handled by shrinkCache()
- */
-export function purgeExpiredSliceCache () {
-  if (typeof window === 'undefined') return;        /* SSR */
-  queueMicrotask(async () => {
-    const now = Date.now();
-    for (const k in localStorage) {
-      if (!k.startsWith(PREFIX)) continue;
-      let drop = false;
-      let obj  = null;
-      try { obj = JSON.parse(localStorage.getItem(k) || '{}'); } catch { drop = true; }
-
-      if (!obj || typeof obj !== 'object') drop = true;
-      else {
-        if (now - (obj.updated || 0) >= DAY_MS) drop = true;
-        if (!obj.total || obj.total === 0)      drop = true;
-
-        /* hash integrity */
-        if (!drop && obj.hash && Array.isArray(obj.slices) && obj.slices.length) {
-          try {
-            const fullHex = obj.slices.join('');
-            const want    = String(obj.hash).replace(/^sha256:/i, '');
-            const got     = await sha256Hex(fullHex);
-            if (got !== want) drop = true;
-          } catch { drop = true; }
-        }
-      }
-      if (drop) try { localStorage.removeItem(k); } catch {}
-    }
-    shrinkCache();                                 /* enforce global cap */
-  });
+export async function saveSliceCheckpoint(contract, tokenId, label, info, net=detectNet()) {
+  const k = keyOf(net, contract, tokenId);
+  const now = Date.now();
+  const prev = (await idbGet(k)) || {};
+  const rec = {
+    tokenKey: `${net}/${contract}/${tokenId}`,
+    createdAt: prev.createdAt || now,
+    updatedAt: now,
+    ...prev,
+    ...info,
+  };
+  await idbSet(k, rec);
 }
 
-/*──────── legacy aliases (r590-r705 b/c) ───────────────────*/
-export const loadSliceCache  = loadSliceCheckpoint;
-export const saveSliceCache  = saveSliceCheckpoint;
+export async function clearSliceCheckpoint(contract, tokenId, _label='artifactUri', net=detectNet()) {
+  await idbDel(keyOf(net, contract, tokenId));
+}
+
+export const loadSliceCache = loadSliceCheckpoint;
+export const saveSliceCache = saveSliceCheckpoint;
 export const clearSliceCache = clearSliceCheckpoint;
 
-/** 32-bit DJB-2 hash – retained for UI checksum previews. */
-export function strHash (s = '') {
-  /* eslint-disable no-bitwise */
-  return s.split('').reduce((h, c) => (h << 5) + h + c.charCodeAt(0), 5381) >>> 0;
-}
+export function purgeExpiredSliceCache() { /* no-op for IDB */ }
+
 /* EOF */

--- a/src/utils/sliceCacheV4a.js
+++ b/src/utils/sliceCacheV4a.js
@@ -1,173 +1,59 @@
-/*Developed by @jams2blues – ZeroContract Studio
+/*─────────────────────────────────────────────────────────────
+  Developed by @jams2blues – ZeroContract Studio
   File:    src/utils/sliceCacheV4a.js
-  Rev :    r707   2025-06-13
-  Summary: drop legacy duplicate block; keep single I60/I61-compliant
-           implementation with back-compat shims.
-─────────────────────────────────────────────────────────────*/
+  Rev :    r1 2025-09-07
+  Summary: IndexedDB-backed slice checkpoints for ZeroTerminal (v4a)
+──────────────────────────────────────────────────────────────*/
+import { get as idbGet, set as idbSet, del as idbDel } from './idbCache.js';
 
-const PREFIX       = 'zuSliceCache';          /* localStorage key-root     */
-const CHUNK_SIZE   = 32_768;                  /* raw-bytes per slice       */
-const BYTES_MAX    = 5 * 1024 * 1024;         /* 5 MB hard cap             */
-const BYTES_TARGET = 4 * 1024 * 1024;         /* shrink-to size on flush   */
-const DAY_MS       = 86_400_000;              /* 24 h                      */
+const PREFIX = 'zu:slice:v4a';
+const detectNet = () => (typeof window === 'undefined' ? 'ghostnet' : (/ghostnet/i.test(window.location.hostname) ? 'ghostnet' : 'mainnet'));
+const keyOf = (net, contract, tokenId, label='artifact') => `${PREFIX}:${net}:${contract}:${tokenId}:${label}`;
 
-/*──────── helpers ───────────────────────────────────────────*/
-
-/** Return `"ghostnet"` | `"mainnet"` by hostname. */
-function detectNet () {
-  if (typeof window === 'undefined') return 'ghostnet';
-  return /ghostnet/i.test(window.location.hostname) ? 'ghostnet' : 'mainnet';
-}
-
-/** Build composite storage key. */
-function keyOf (net, contract, tokenId, label = 'artifact') {
-  return `${PREFIX}:${net}:${contract}:${tokenId}:${label}`;
-}
-
-/** Async SHA-256 digest → hex. */
-async function sha256Hex (txt = '') {
-  const buf  = new TextEncoder().encode(txt);
-  const hash = await crypto.subtle.digest('SHA-256', buf);
-  return Array.from(new Uint8Array(hash))
-    .map((b) => b.toString(16).padStart(2, '0'))
-    .join('');
-}
-
-/*──────── size helpers ─────────────────────────────────────*/
-
-function cacheBytes () {
-  let n = 0;
-  for (const k in localStorage) {
-    if (k.startsWith(PREFIX)) n += k.length + localStorage.getItem(k).length;
-  }
-  return n;
-}
-
-function shrinkCache () {
-  let total = cacheBytes();
-  if (total <= BYTES_MAX) return;
-
-  const items = [];
-  for (const k in localStorage) {
-    if (!k.startsWith(PREFIX)) continue;
-    try {
-      const { updated = 0 } = JSON.parse(localStorage.getItem(k) || '{}');
-      items.push({ k, updated });
-    } catch { localStorage.removeItem(k); }
-  }
-  items.sort((a, b) => a.updated - b.updated);       /* oldest first */
-  for (const { k } of items) {
-    localStorage.removeItem(k);
-    total = cacheBytes();
-    if (total <= BYTES_TARGET) break;
-  }
-}
-
-/*──────── core API ─────────────────────────────────────────*/
-
-/**
- * Load checkpoint or null.
- * @returns {object|null}
- */
-export function loadSliceCheckpoint (
-  contract,
-  tokenId,
-  label = 'artifact',
-  net   = detectNet(),
-) {
+async function migrateLocal(contract, tokenId, label, net) {
+  if (typeof localStorage === 'undefined') return null;
+  const oldKey = `zuSliceCache:${net}:${contract}:${tokenId}:${label}`;
+  const raw = localStorage.getItem(oldKey);
+  if (!raw) return null;
   try {
-    const raw = localStorage.getItem(keyOf(net, contract, tokenId, label));
-    return raw ? JSON.parse(raw) : null;
-  } catch { return null; }
-}
-
-/**
- * Persist / merge checkpoint (idempotent).
- * `info` may supply either `next` or legacy `nextIdx`.
- */
-export function saveSliceCheckpoint (
-  contract,
-  tokenId,
-  label,
-  info,
-  net = detectNet(),
-) {
-  try {
+    const obj = JSON.parse(raw);
     const now = Date.now();
-    const rec = {
-      tokenId : +tokenId,
-      label,
-      chunkSize: CHUNK_SIZE,
-      updated  : now,
-      ...info,
-    };
-    if (rec.next == null && rec.nextIdx != null) rec.next = rec.nextIdx;
-    localStorage.setItem(
-      keyOf(net, contract, tokenId, label),
-      JSON.stringify(rec),
-    );
-    shrinkCache();
-  } catch {/* quota / private-mode – ignore */}
+    const rec = { tokenId:+tokenId, label, chunkSize: obj.chunkSize || 32_768, updated: now, created: obj.created || now, ...obj };
+    await idbSet(keyOf(net, contract, tokenId, label), rec);
+    localStorage.removeItem(oldKey);
+    return rec;
+  } catch {
+    return null;
+  }
 }
 
-/** Delete checkpoint. */
-export function clearSliceCheckpoint (
-  contract,
-  tokenId,
-  label = 'artifact',
-  net   = detectNet(),
-) {
-  try { localStorage.removeItem(keyOf(net, contract, tokenId, label)); } catch {}
+export async function loadSliceCheckpoint(contract, tokenId, label='artifact', net=detectNet()) {
+  const k = keyOf(net, contract, tokenId, label);
+  let row = await idbGet(k);
+  if (!row) row = await migrateLocal(contract, tokenId, label, net);
+  return row || null;
 }
 
-/*──────── hygiene (I61) ────────────────────────────────────*/
-
-/**
- * Non-blocking purge – runs in micro-task.
- *  • updated ≥ 24 h
- *  • total === 0
- *  • hash mismatch
- *  • global size cap handled by shrinkCache()
- */
-export function purgeExpiredSliceCache () {
-  if (typeof window === 'undefined') return;        /* SSR */
-  queueMicrotask(async () => {
-    const now = Date.now();
-    for (const k in localStorage) {
-      if (!k.startsWith(PREFIX)) continue;
-      let drop = false;
-      let obj  = null;
-      try { obj = JSON.parse(localStorage.getItem(k) || '{}'); } catch { drop = true; }
-
-      if (!obj || typeof obj !== 'object') drop = true;
-      else {
-        if (now - (obj.updated || 0) >= DAY_MS) drop = true;
-        if (!obj.total || obj.total === 0)      drop = true;
-
-        /* hash integrity */
-        if (!drop && obj.hash && Array.isArray(obj.slices) && obj.slices.length) {
-          try {
-            const fullHex = obj.slices.join('');
-            const want    = String(obj.hash).replace(/^sha256:/i, '');
-            const got     = await sha256Hex(fullHex);
-            if (got !== want) drop = true;
-          } catch { drop = true; }
-        }
-      }
-      if (drop) try { localStorage.removeItem(k); } catch {}
-    }
-    shrinkCache();                                 /* enforce global cap */
-  });
+export async function saveSliceCheckpoint(contract, tokenId, label, info, net=detectNet()) {
+  const k = keyOf(net, contract, tokenId, label);
+  const now = Date.now();
+  const prev = (await idbGet(k)) || {};
+  const rec = { tokenId:+tokenId, label, created: prev.created || now, updated: now, ...prev, ...info };
+  await idbSet(k, rec);
 }
 
-/*──────── legacy aliases (r590-r705 b/c) ───────────────────*/
-export const loadSliceCache  = loadSliceCheckpoint;
-export const saveSliceCache  = saveSliceCheckpoint;
+export async function clearSliceCheckpoint(contract, tokenId, label='artifact', net=detectNet()) {
+  await idbDel(keyOf(net, contract, tokenId, label));
+}
+
+export const loadSliceCache = loadSliceCheckpoint;
+export const saveSliceCache = saveSliceCheckpoint;
 export const clearSliceCache = clearSliceCheckpoint;
 
-/** 32-bit DJB-2 hash – retained for UI checksum previews. */
-export function strHash (s = '') {
+export function purgeExpiredSliceCache() { /* no-op for IDB */ }
+
+export function strHash(s='') {
   /* eslint-disable no-bitwise */
-  return s.split('').reduce((h, c) => (h << 5) + h + c.charCodeAt(0), 5381) >>> 0;
+  return s.split('').reduce((h,c)=>(h<<5)+h+c.charCodeAt(0),5381)>>>0;
 }
 /* EOF */

--- a/src/utils/uriHelpers.js
+++ b/src/utils/uriHelpers.js
@@ -1,9 +1,10 @@
 /*─────────────────────────────────────────────────────────────
   Developed by @jams2blues – ZeroContract Studio
   File:    src/utils/uriHelpers.js
-  Rev :    r600   2025-07-10
-  Summary: added mimeFromDataUri helper
+  Rev :    r601   2025-09-07
+  Summary: add data-URI validators and normaliser
 ──────────────────────────────────────────────────────────────*/
+import { Buffer } from 'buffer';
 
 /** Regex matching metadata keys that store media/data URIs. */
 export const URI_KEY_REGEX = /^(artifactUri|displayUri|thumbnailUri|extrauri_)/i;
@@ -26,6 +27,27 @@ export function listUriKeys(meta) {
  */
 export function mimeFromDataUri(u = '') {
   return u.startsWith('data:') ? (u.slice(5).split(/[;,]/)[0] || '') : '';
+}
+
+export function isValidDataUri(u = '') {
+  return /^data:[^,]+,.+/.test(u);
+}
+
+export function isLikelySvg(s = '') {
+  return /<svg[\s>]/i.test(s);
+}
+
+export function ensureDataUri(u = '') {
+  if (!isValidDataUri(u)) throw new Error('Invalid data URI');
+  const [meta, body] = u.slice(5).split(',', 2);
+  const parts = meta.split(';');
+  const mime = parts[0].toLowerCase();
+  const isBase64 = parts.includes('base64');
+  if (mime === 'image/svg+xml' && isBase64) {
+    const decoded = Buffer.from(body, 'base64').toString('utf8');
+    return `data:${mime};utf8,${decoded}`;
+  }
+  return `data:${mime}${isBase64 ? ';base64' : ';utf8'},${body}`;
 }
 /* What changed & why: Date aligned; minor doc polish; no functional change.
 */


### PR DESCRIPTION
## Summary
- add canonical head/tail slicer and append call builder
- move slice checkpoint cache to IndexedDB
- validate data URIs and cover slicing with tests

## Testing
- `yarn lint` *(fails: keepSellersWithBalanceAtLeast is defined but never used)*
- `yarn test` *(fails: dynamic import callback invoked without --experimental-vm-modules)*
- `yarn build`

| rev | ✔ | files | outcome |
| --- | --- | ----- | ------- |
| r2 | ⚠ | slicer,idb cache | lint/test failures |

------
https://chatgpt.com/codex/tasks/task_e_68a7b2b35b288330b0204b63e25c0c6d